### PR TITLE
Prevent error installing without tomcat9

### DIFF
--- a/debian/package/debian/pihemr.preinst
+++ b/debian/package/debian/pihemr.preinst
@@ -12,8 +12,10 @@ case "$1" in
     # then
       # sh /usr/local/sbin/mysqlbackup.sh $2
     # fi
-
-    service tomcat9 stop
+    #Tomcat setup is now in puppet, and may use docker.  Stop service only if it exists.
+    if service --status-all | grep -Fq 'tomcat9'; then
+      service tomcat9 stop
+    fi
 
     rm -rf /var/lib/tomcat9/webapps/openmrs
     rm -rf /var/lib/tomcat9/webapps/mirebalais


### PR DESCRIPTION
This change is to address an error updating the pihemr deb package on servers using docker to run tomcat.